### PR TITLE
URLを直接指定すると他のユーザーのタスクが見えてしまう

### DIFF
--- a/lib/todo_app_web/live/task_live/show.ex
+++ b/lib/todo_app_web/live/task_live/show.ex
@@ -10,10 +10,17 @@ defmodule TodoAppWeb.TaskLive.Show do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
-    {:noreply,
-     socket
-     |> assign(:page_title, page_title(socket.assigns.live_action))
-     |> assign(:task, Tasks.get_task!(id))}
+    task = Tasks.get_task!(id)
+    current_account_id = socket.assigns.current_account.id
+
+    if task.account_id == current_account_id do
+      {:noreply,
+       socket
+       |> assign(:page_title, page_title(socket.assigns.live_action))
+       |> assign(:task, Tasks.get_task!(id))}
+    else
+      {:noreply, redirect(socket, to: ~p"/")}
+    end
   end
 
   defp page_title(:show), do: "Show Task"


### PR DESCRIPTION
タスクの詳細画面が他のユーザーから見えないようにしました。

自分でマージします

Fixes #9